### PR TITLE
Add missing headers

### DIFF
--- a/src/libime/core/languagemodel.h
+++ b/src/libime/core/languagemodel.h
@@ -9,6 +9,7 @@
 #include "datrie.h"
 #include "libimecore_export.h"
 #include <fcitx-utils/macros.h>
+#include <limits>
 #include <memory>
 #include <string_view>
 #include <vector>


### PR DESCRIPTION
Similar to https://github.com/fcitx/fcitx5/pull/166 , `limits` must be explicitly included when building with GCC 11 prerelease.