### PR TITLE
Load libime history from text.

### DIFF
--- a/src/libime/core/historybigram.cpp
+++ b/src/libime/core/historybigram.cpp
@@ -14,6 +14,7 @@
 #include <boost/range/algorithm.hpp>
 #include <cmath>
 #include <fcitx-utils/log.h>
+#include <fcitx-utils/stringutils.h>
 
 namespace libime {
 
@@ -153,6 +154,20 @@ public:
                 throw_if_io_fail(unmarshallString(in, buffer));
                 sentence.emplace_back(std::move(buffer));
             }
+            add(sentence);
+        }
+    }
+
+    void loadText(std::istream &in) {
+        clear();
+        std::string buf;
+        std::vector<std::string> lines;
+        while (std::getline(in, buf)) {
+            lines.emplace_back(buf);
+            if (lines.size() >= maxSize_) break;
+        }
+        for(auto &line : lines | boost::adaptors::reversed) {
+            std::vector<std::string> sentence = fcitx::stringutils::split(line, " ");
             add(sentence);
         }
     }
@@ -481,6 +496,11 @@ void HistoryBigram::load(std::istream &in) {
         throw std::invalid_argument("Invalid history version.");
     }
     }
+}
+
+void HistoryBigram::loadText(std::istream &in) {
+    FCITX_D();
+    boost::range::for_each(d->pools_, [&in](auto &pool) { pool.loadText(in); });
 }
 
 void HistoryBigram::save(std::ostream &out) {

--- a/src/libime/core/historybigram.h
+++ b/src/libime/core/historybigram.h
@@ -26,6 +26,7 @@ public:
     FCITX_DECLARE_VIRTUAL_DTOR_MOVE(HistoryBigram);
 
     void load(std::istream &in);
+    void loadText(std::istream &in);
     void save(std::ostream &out);
     void dump(std::ostream &out);
     void clear();

--- a/tools/libime_history.cpp
+++ b/tools/libime_history.cpp
@@ -10,15 +10,20 @@
 #include <iostream>
 
 void usage(const char *argv0) {
-    std::cout << "Usage: " << argv0 << " <source> <dest>" << std::endl
+    std::cout << "Usage: " << argv0 << " [-c] <source> <dest>" << std::endl
+              << "-c: Compile text to binary" << std::endl
               << "-h: Show this help" << std::endl;
 }
 
 int main(int argc, char *argv[]) {
 
+    bool compile = false;
     int c;
-    while ((c = getopt(argc, argv, "h")) != -1) {
+    while ((c = getopt(argc, argv, "ch")) != -1) {
         switch (c) {
+        case 'c':
+            compile = true;
+            break;
         case 'h':
             usage(argv[0]);
             return 0;
@@ -36,7 +41,11 @@ int main(int argc, char *argv[]) {
     HistoryBigram history;
 
     std::ifstream in(argv[optind], std::ios::in | std::ios::binary);
-    history.load(in);
+    if (compile) {
+        history.loadText(in);
+    } else {
+        history.load(in);
+    }
 
     std::ofstream fout;
     std::ostream *out;
@@ -46,6 +55,10 @@ int main(int argc, char *argv[]) {
         fout.open(argv[optind + 1], std::ios::out | std::ios::binary);
         out = &fout;
     }
-    history.dump(*out);
+    if (compile) {
+        history.save(*out);
+    } else {
+        history.dump(*out);
+    }
     return 0;
 }


### PR DESCRIPTION
Implement loading libime history from text file, so we are now able to compile text history to binary format.