### PR TITLE
migiate nan float issue on certain platform by introduce ...Raw() variant function to DATrie

### DIFF
--- a/src/libime/core/datrie.h
+++ b/src/libime/core/datrie.h
@@ -90,6 +90,11 @@ public:
         return exactMatchSearch(key.data(), key.size());
     }
 
+    int32_t exactMatchSearchRaw(const char *key, size_t len) const;
+    int32_t exactMatchSearchRaw(std::string_view key) const {
+        return exactMatchSearchRaw(key.data(), key.size());
+    }
+
     bool hasExactMatch(std::string_view key) const;
 
     DATrie<T>::value_type traverse(std::string_view key,
@@ -98,6 +103,11 @@ public:
     }
     DATrie<T>::value_type traverse(const char *key, size_t len,
                                    position_type &from) const;
+
+    int32_t traverseRaw(std::string_view key, position_type &from) const {
+        return traverseRaw(key.data(), key.size(), from);
+    }
+    int32_t traverseRaw(const char *key, size_t len, position_type &from) const;
 
     // set value
     void set(std::string_view key, value_type val) {
@@ -138,8 +148,14 @@ public:
     static bool isNoPath(value_type v);
     static bool isNoValue(value_type v);
 
+    static bool isValidRaw(int32_t v);
+    static bool isNoPathRaw(int32_t v);
+    static bool isNoValueRaw(int32_t v);
+
     static value_type noPath();
     static value_type noValue();
+
+    static value_type decode(int32_t raw);
 
     size_t mem_size() const;
 

--- a/src/libime/pinyin/pinyindictionary.cpp
+++ b/src/libime/pinyin/pinyindictionary.cpp
@@ -17,6 +17,8 @@
 #include "pinyinmatchstate_p.h"
 #include <boost/algorithm/string.hpp>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <fstream>
 #include <iomanip>
 #include <optional>
@@ -158,10 +160,10 @@ inline void searchOneStep(
     auto iter = nodes.begin();
     while (iter != nodes.end()) {
         if (current != 0) {
-            PinyinTrie::value_type result;
-            result = iter->first->traverse(&current, 1, iter->second);
+            const auto resultRaw =
+                iter->first->traverseRaw(&current, 1, iter->second);
 
-            if (PinyinTrie::isNoPath(result)) {
+            if (PinyinTrie::isNoPathRaw(resultRaw)) {
                 nodes.erase(iter++);
             } else {
                 iter++;
@@ -171,8 +173,8 @@ inline void searchOneStep(
             for (char test = PinyinEncoder::firstFinal;
                  test <= PinyinEncoder::lastFinal; test++) {
                 decltype(extraNodes)::value_type p = *iter;
-                auto result = p.first->traverse(&test, 1, p.second);
-                if (!PinyinTrie::isNoPath(result)) {
+                const auto resultRaw = p.first->traverseRaw(&test, 1, p.second);
+                if (!PinyinTrie::isNoPathRaw(resultRaw)) {
                     extraNodes.push_back(p);
                     changed = true;
                 }
@@ -371,8 +373,8 @@ PinyinTriePositions traverseAlongPathOneStepBySyllables(
             // make a copy
             auto pos = _pos;
             auto initial = static_cast<char>(syl.first);
-            auto result = path.trie()->traverse(&initial, 1, pos);
-            if (PinyinTrie::isNoPath(result)) {
+            const auto resultRaw = path.trie()->traverseRaw(&initial, 1, pos);
+            if (PinyinTrie::isNoPathRaw(resultRaw)) {
                 continue;
             }
             const auto &finals = syl.second;
@@ -381,9 +383,9 @@ PinyinTriePositions traverseAlongPathOneStepBySyllables(
                                                            size_t fuzzyFactor,
                                                            auto pos) {
                 auto final = static_cast<char>(pyFinal);
-                auto result = path.trie()->traverse(&final, 1, pos);
+                const auto resultRaw = path.trie()->traverseRaw(&final, 1, pos);
 
-                if (!PinyinTrie::isNoPath(result)) {
+                if (!PinyinTrie::isNoPathRaw(resultRaw)) {
                     size_t newFuzzies = fuzzies + fuzzyFactor;
                     positions.emplace_back(pos, newFuzzies);
                 }
@@ -446,8 +448,8 @@ void matchWordsOnTrie(const PinyinTrie *userDict, const MatchedPinyinPath &path,
                 pos);
         } else {
             const char sep = pinyinHanziSep;
-            auto result = path.trie()->traverse(&sep, 1, pos);
-            if (PinyinTrie::isNoPath(result)) {
+            const auto resultRaw = path.trie()->traverseRaw(&sep, 1, pos);
+            if (PinyinTrie::isNoPathRaw(resultRaw)) {
                 continue;
             }
 

--- a/src/libime/pinyin/pinyindictionary.h
+++ b/src/libime/pinyin/pinyindictionary.h
@@ -7,10 +7,20 @@
 #define _FCITX_LIBIME_PINYIN_PINYINDICTIONARY_H_
 
 #include "libimepinyin_export.h"
+#include <cstddef>
+#include <fcitx-utils/flags.h>
 #include <fcitx-utils/macros.h>
+#include <functional>
+#include <istream>
+#include <libime/core/dictionary.h>
+#include <libime/core/segmentgraph.h>
 #include <libime/core/triedictionary.h>
 #include <libime/pinyin/pinyinencoder.h>
 #include <memory>
+#include <optional>
+#include <ostream>
+#include <string_view>
+#include <unordered_set>
 
 namespace libime {
 
@@ -18,9 +28,8 @@ enum class PinyinDictFormat { Text, Binary };
 
 class PinyinDictionaryPrivate;
 
-typedef std::function<bool(std::string_view encodedPinyin,
-                           std::string_view hanzi, float cost)>
-    PinyinMatchCallback;
+using PinyinMatchCallback =
+    std::function<bool(std::string_view, std::string_view, float)>;
 
 using PinyinTrie = typename TrieDictionary::TrieType;
 
@@ -64,7 +73,7 @@ public:
     void save(size_t idx, std::ostream &out, PinyinDictFormat format);
 
     void addWord(size_t idx, std::string_view fullPinyin,
-                 std::string_view hanzi, float cost = 0.0f);
+                 std::string_view hanzi, float cost = 0.0F);
     bool removeWord(size_t idx, std::string_view fullPinyin,
                     std::string_view hanzi);
     std::optional<float> lookupWord(size_t idx, std::string_view fullPinyin,

--- a/src/libime/table/tablebaseddictionary.cpp
+++ b/src/libime/table/tablebaseddictionary.cpp
@@ -24,6 +24,7 @@
 #include <fcitx-utils/stringutils.h>
 #include <fcitx-utils/utf8.h>
 #include <fstream>
+#include <iterator>
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -275,7 +276,7 @@ bool TableBasedDictionaryPrivate::matchTrie(
                     auto curPos = position;
                     auto strCode = fcitx::utf8::UCS4ToUTF8(code);
                     auto result = trie.traverse(strCode, curPos);
-                    if (!trie.isNoPath(result)) {
+                    if (!DATrie<unsigned int>::isNoPath(result)) {
                         newPositions.push_back(curPos);
                     }
                 }
@@ -286,7 +287,7 @@ bool TableBasedDictionaryPrivate::matchTrie(
                     std::distance(charRange.first, charRange.second));
                 auto curPos = position;
                 auto result = trie.traverse(chr, curPos);
-                if (!trie.isNoPath(result)) {
+                if (!DATrie<unsigned int>::isNoPath(result)) {
                     newPositions.push_back(curPos);
                 }
             }

--- a/test/testtrie.cpp
+++ b/test/testtrie.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 #include "libime/core/datrie.h"
+#include <cstdint>
 #include <cstring>
 #include <fcitx-utils/log.h>
 
@@ -39,8 +40,8 @@ int main() {
         FCITX_ASSERT(trie.size() == 4);
         DATrie<float>::position_type pos = 0;
         auto result = trie.traverse("aaa", pos);
-        auto nan1 = trie.noValue();
-        auto nan2 = trie.noPath();
+        auto nan1 = DATrie<float>::noValue();
+        auto nan2 = DATrie<float>::noPath();
         // NaN != NaN, we must use memcmp to do this.
         FCITX_ASSERT(memcmp(&nan1, &result, sizeof(float)) == 0);
         FCITX_ASSERT(trie.isNoValue(result));


### PR DESCRIPTION
On certain platform, nan may be canonicalized to a different value. So
DATrie<float> may need to be very careful to do comparison for check
value. So instead, we introduce Raw() function to directly return the
internal representation int32_t for value comparison. And only decode
when the value is valid.
