### PR TITLE
Seems kenlm can be built with C++20, remove the CXX_STANDARD for kenlm

### DIFF
--- a/src/libime/core/CMakeLists.txt
+++ b/src/libime/core/CMakeLists.txt
@@ -14,8 +14,13 @@ target_include_directories(kenlm PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE
 target_compile_definitions(kenlm PUBLIC -DKENLM_MAX_ORDER=3 PRIVATE -DNDEBUG)
 target_link_libraries(kenlm PUBLIC Boost::boost PkgConfig::ZSTD)
 set_target_properties(kenlm PROPERTIES
-  CXX_STANDARD 11
   POSITION_INDEPENDENT_CODE ON)
+
+include(CheckCXXSymbolExists)
+check_cxx_symbol_exists(_LIBCPP_VERSION version LIBCPP)
+if(LIBCPP)
+  target_compile_definitions(kenlm PUBLIC -D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
+endif()
 
 if(UNIX)
   check_library_exists(rt clock_gettime "clock_gettime from librt" HAVE_CLOCKGETTIME_RT)


### PR DESCRIPTION
kenlm was compiled with C++11 while others using C++20 think the
std::string is violating odr.
Ref: https://bugs.gentoo.org/962546
