### PR TITLE
Use enum to represent the select segment type

### DIFF
--- a/test/testpinyincontext.cpp
+++ b/test/testpinyincontext.cpp
@@ -235,6 +235,16 @@ int main() {
         c.type("shounihao");
         FCITX_ASSERT(c.candidatesToCursorSet().count("✋你好") > 0);
     }
+    {
+        c.clear();
+        c.type("er");
+        c.selectCustom(2, "");
+        FCITX_ASSERT(c.selected());
+        FCITX_ASSERT(c.selectedSentence() == "");
+        FCITX_ASSERT(c.selectedWords().size() == 1);
+        FCITX_ASSERT(c.selectedWords().front().empty());
+        FCITX_ASSERT(c.selectedWordsWithPinyin().size() == 1);
+    }
 
     return 0;
 }


### PR DESCRIPTION
Previously, we use "word.empty()" to skip possible separator only segments
e.g. "xi'", "'" may be consumed as a single segment. Howver, with
selectCustom, this does not hold anymore. And this would be causing
issues when other code assume there should be selected segments.
