### PR TITLE
fix unused variable d

### DIFF
--- a/src/libime/core/historybigram.cpp
+++ b/src/libime/core/historybigram.cpp
@@ -559,7 +559,6 @@ bool HistoryBigram::useOnlyUnigram() const {
 }
 
 void HistoryBigram::add(const libime::SentenceResult &sentence) {
-    FCITX_D();
     addWithCode(sentence, nullptr);
 }
 

--- a/src/libime/core/triedictionary.cpp
+++ b/src/libime/core/triedictionary.cpp
@@ -67,7 +67,6 @@ const TrieDictionary::TrieType *TrieDictionary::trie(size_t idx) const {
 }
 
 void TrieDictionary::setTrie(size_t idx, TrieType trie) {
-    FCITX_D();
     *mutableTrie(idx) = std::move(trie);
     emit<TrieDictionary::dictionaryChanged>(idx);
 }


### PR DESCRIPTION
```
/Users/runner/work/fcitx5-ios/fcitx5-ios/engines/libime/src/libime/core/historybigram.cpp:562:5: warning: unused variable 'd' [-Wunused-variable]
  562 |     FCITX_D();
      |     ^~~~~~~~~
/Users/runner/work/fcitx5-ios/fcitx5-ios/fcitx5/src/lib/fcitx-utils/../fcitx-utils/macros.h:21:31: note: expanded from macro 'FCITX_D'
   21 | #define FCITX_D() auto *const d = d_func()
      |                               ^
1 warning generated.
```