### PR TITLE
Add opt-in pinyin transposition correction

### DIFF
--- a/src/libime/pinyin/pinyincorrectionprofile.cpp
+++ b/src/libime/pinyin/pinyincorrectionprofile.cpp
@@ -62,16 +62,27 @@ PinyinCorrectionProfile::PinyinCorrectionProfile(
     : PinyinCorrectionProfile(getProfileMapping(profile)) {}
 
 PinyinCorrectionProfile::PinyinCorrectionProfile(
+    BuiltinPinyinCorrectionProfile profile, bool enableTransposition)
+    : PinyinCorrectionProfile(getProfileMapping(profile), enableTransposition) {
+}
+
+PinyinCorrectionProfile::PinyinCorrectionProfile(
     const std::unordered_map<char, std::vector<char>> &mapping)
+    : PinyinCorrectionProfile(mapping, false) {}
+
+PinyinCorrectionProfile::PinyinCorrectionProfile(
+    const std::unordered_map<char, std::vector<char>> &mapping,
+    bool enableTransposition)
     : d_ptr(std::make_unique<PinyinCorrectionProfilePrivate>()) {
     FCITX_D();
     d->correctionMap_ = mapping;
     // Fill with the original pinyin map.
     d->pinyinMap_ = getPinyinMapV2();
-    if (mapping.empty()) {
+    if (mapping.empty() && !enableTransposition) {
         return;
     }
-    // Re-map all entry with the correction mapping.
+    // Re-map all entry with the correction mapping and optional adjacent
+    // transposition.
     std::vector<PinyinEntry> newEntries;
     for (const auto &item : d->pinyinMap_) {
         for (size_t i = 0; i < item.pinyin().size(); i++) {
@@ -87,6 +98,19 @@ PinyinCorrectionProfile::PinyinCorrectionProfile(
                     PinyinEntry(newEntry.data(), item.initial(), item.final(),
                                 item.flags() | PinyinFuzzyFlag::Correction));
                 newEntry[i] = chr;
+            }
+        }
+        if (enableTransposition) {
+            auto newEntry = item.pinyin();
+            for (size_t i = 0; i + 1 < item.pinyin().size(); i++) {
+                if (newEntry[i] == newEntry[i + 1]) {
+                    continue;
+                }
+                std::swap(newEntry[i], newEntry[i + 1]);
+                newEntries.push_back(
+                    PinyinEntry(newEntry.data(), item.initial(), item.final(),
+                                item.flags() | PinyinFuzzyFlag::Correction));
+                std::swap(newEntry[i], newEntry[i + 1]);
             }
         }
     }

--- a/src/libime/pinyin/pinyincorrectionprofile.h
+++ b/src/libime/pinyin/pinyincorrectionprofile.h
@@ -44,6 +44,16 @@ public:
     explicit PinyinCorrectionProfile(BuiltinPinyinCorrectionProfile profile);
 
     /**
+     * Construct the profile based on builtin layout.
+     *
+     * @param profile built-in profile
+     * @param enableTransposition enable correction for adjacent letter
+     * transposition, e.g. zhong -> zhogn.
+     */
+    explicit PinyinCorrectionProfile(BuiltinPinyinCorrectionProfile profile,
+                                     bool enableTransposition);
+
+    /**
      * Construct the profile based on customized mapping.
      *
      * E.g. w may be corrected to q,e, the mapping will contain {'w': ['q',
@@ -53,6 +63,17 @@ public:
      */
     explicit PinyinCorrectionProfile(
         const std::unordered_map<char, std::vector<char>> &mapping);
+
+    /**
+     * Construct the profile based on customized mapping.
+     *
+     * @param mapping pinyin character and the corresponding possible wrong key.
+     * @param enableTransposition enable correction for adjacent letter
+     * transposition, e.g. zhong -> zhogn.
+     */
+    explicit PinyinCorrectionProfile(
+        const std::unordered_map<char, std::vector<char>> &mapping,
+        bool enableTransposition);
 
     virtual ~PinyinCorrectionProfile();
 

--- a/test/testpinyinencoder.cpp
+++ b/test/testpinyinencoder.cpp
@@ -280,6 +280,28 @@ int main() {
                                                PinyinFuzzyFlag::Correction);
         dfs(graph, {"suan", "g"});
     }
+    {
+        PinyinCorrectionProfile defaultProfile(
+            BuiltinPinyinCorrectionProfile::Qwerty);
+        FCITX_ASSERT(
+            PinyinEncoder::stringToSyllablesWithFuzzyFlags(
+                "zhogn", &defaultProfile, PinyinFuzzyFlag::Correction) !=
+            MatchedPinyinSyllablesWithFuzzyFlags{
+                {PinyinInitial::ZH,
+                 {{PinyinFinal::ONG, PinyinFuzzyFlag::Correction}}}});
+
+        PinyinCorrectionProfile profile(BuiltinPinyinCorrectionProfile::Qwerty,
+                                        true);
+        auto graph = PinyinEncoder::parseUserPinyin(
+            "zhogn", &profile, PinyinFuzzyFlag::Correction);
+        dfs(graph, {"zhogn"});
+
+        FCITX_ASSERT(PinyinEncoder::stringToSyllablesWithFuzzyFlags(
+                         "zhogn", &profile, PinyinFuzzyFlag::Correction) ==
+                     MatchedPinyinSyllablesWithFuzzyFlags{
+                         {PinyinInitial::ZH,
+                          {{PinyinFinal::ONG, PinyinFuzzyFlag::Correction}}}});
+    }
 
     {
         ShuangpinProfile sp(ShuangpinBuiltinProfile::Xiaohe);


### PR DESCRIPTION
### Problem

Fast pinyin typing can produce adjacent-letter transpositions such as `zhogn` for `zhong`. Existing `PinyinCorrectionProfile` covers keyboard-neighbor substitution, but this is a different typo class.

Refs #127.

### Approach

This adds opt-in constructors for `PinyinCorrectionProfile` that enable adjacent transposition entries in the generated pinyin map. These entries reuse the existing `PinyinFuzzyFlag::Correction` path, so dictionary scoring and correction filtering stay unchanged.

Existing constructors continue to pass `enableTransposition=false`, preserving current behavior by default.

### Validation

Local macOS 26 / AppleClang 21 validation:

```text
DYLD_LIBRARY_PATH=/Users/larry_1/scratch-data/pinyin-ime-prefix/lib:build/bin \
  ctest --test-dir build -R '^testpinyinencoder$' --output-on-failure
100% tests passed, 0 tests failed out of 1

DYLD_LIBRARY_PATH=/Users/larry_1/scratch-data/pinyin-ime-prefix/lib:build/bin \
  ctest --test-dir build --output-on-failure
100% tests passed, 0 tests failed out of 16
```

Microbenchmark around `PinyinEncoder::parseUserPinyin` stayed at single-digit microseconds on average on this machine; profile construction increased by roughly 0.18 ms mean in the measured run.
