### PR TITLE
LRUCache: make insert() more robust against duplicate keys

### DIFF
--- a/src/libime/core/lrucache.h
+++ b/src/libime/core/lrucache.h
@@ -40,19 +40,31 @@ public:
 
     template <typename... Args>
     value_type *insert(const key_type &key, Args &&...args) {
-        auto iter = dict_.find(key);
-        if (iter == dict_.end()) {
-            if (size() >= sz_) {
-                evict();
-            }
+        if (sz_ == 0) {
+            return nullptr;
+        }
 
-            order_.push_front(key);
-            auto r = dict_.emplace(
-                key, std::make_pair(value_type(std::forward<Args>(args)...),
-                                    order_.begin()));
+        auto iter = dict_.find(key);
+        if (iter != dict_.end()) {
+            return &iter->second.first;
+        }
+
+        if (size() >= sz_) {
+            evict();
+        }
+
+        auto listIter = order_.insert(order_.begin(), key);
+
+        auto r = dict_.emplace(key,
+                               std::make_pair(value_type(std::forward<Args>(args)...),
+                                              listIter));
+
+        if (!r.second) {
+            order_.erase(listIter);
             return &r.first->second.first;
         }
-        return nullptr;
+
+        return &r.first->second.first;
     }
 
     void erase(const key_type &key) {
@@ -86,6 +98,7 @@ public:
 private:
     void evict() {
         // evict item from the end of most recently used list
+        assert(!order_.empty());
         auto i = std::prev(order_.end());
         dict_.erase(*i);
         order_.erase(i);

--- a/src/libime/pinyin/pinyindictionary.cpp
+++ b/src/libime/pinyin/pinyindictionary.cpp
@@ -544,6 +544,10 @@ bool PinyinDictionaryPrivate::matchWordsForOnePath(
         if (!result) {
             result =
                 matchCache.insert(context.hasher_.pathToPinyins(path.path_));
+            if (!result) {
+                FCITX_ERROR() << "Unexpected nullptr from insert";
+                return false;
+            }
             result->clear();
 
             auto &items = *result;


### PR DESCRIPTION
While debugging a crash in libime 1.0.7, I noticed a corner case in LRUCache::insert() that may be worth discussing.

The cache returns nullptr when the key already exists. Some call sites appear to assume that insert() always returns a valid pointer and immediately dereference the result. In my case this eventually led to a crash while entering pinyin text.

I was only able to reproduce the problem on libime 1.0.7. After upgrading to libime 1.0.17, I could no longer reproduce the original crash, so this may already be fixed indirectly by other changes.

The attached patch changes insert() to return the existing entry when the key is already present, adds a guard for zero-capacity caches, and adds a sanity check in evict().

I cannot say that this is the root cause of the issue. However, the patch applies cleanly to current master and makes the cache API more defensive against accidental misuse.

Please feel free to close this PR if the current behavior is intentional or if there is already a preferred solution. I mainly wanted to share the findings from the investigation in case they are useful.