### PR TITLE
Update inner segment handling for "n" segment

### DIFF
--- a/src/libime/pinyin/pinyinencoder.cpp
+++ b/src/libime/pinyin/pinyinencoder.cpp
@@ -322,18 +322,15 @@ PinyinEncoder::parseUserPinyin(std::string userPinyin,
                         auto iter = innerSegments.find(nextPinyin);
                         if (iter != innerSegments.end()) {
                             for (const auto &innerSeg : iter->second) {
-                                if (innerSeg.second == "n") {
-                                    bool accept =
-                                        (top + nextSize[i] < pinyin.size()) ||
-                                        (i == 0 && nNextSize == 1);
-                                    if (!accept) {
-                                        continue;
-                                    }
-                                }
                                 result.addNext(top,
                                                top + innerSeg.first.size());
-                                result.addNext(top + innerSeg.first.size(),
-                                               top + nextSize[i]);
+                                // Skip "n", in case n can have a better match.
+                                if (innerSeg.second == "n") {
+                                    q.push(top + innerSeg.first.size());
+                                } else {
+                                    result.addNext(top + innerSeg.first.size(),
+                                                   top + nextSize[i]);
+                                }
                             }
                         }
                     } else if (nextPinyin.size() == 2 &&

--- a/test/testpinyinencoder.cpp
+++ b/test/testpinyinencoder.cpp
@@ -291,6 +291,12 @@ int main() {
         graph = PinyinEncoder::parseUserPinyin("to", &profile,
                                                PinyinFuzzyFlag::InnerShort);
         dfs(graph, {"t", "o"});
+        graph = PinyinEncoder::parseUserPinyin(
+            "xiana", &profile,
+            {PinyinFuzzyFlag::PartialFinal, PinyinFuzzyFlag::InnerShort});
+        dfs(graph, {"xian", "a"});
+        dfs(graph, {"xia", "na"});
+        dfs(graph, {"xi", "a", "na"});
     }
 
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pinyin parsing for inputs containing ambiguous “n” segments.
  * Corrected segmentation behavior for partial-final and inner-short fuzzy matching.

* **Tests**
  * Added coverage for multiple valid segmentations of “xiana,” including “xian-a,” “xia-na,” and “xi-a-na.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->